### PR TITLE
fixed necessary dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords" : ["deploy","join","one-file","prettyprint","manipulate"],
 	"homepage" : "https://www.github.com/codeless/jugglecode",
 	"require" : {
-		"nikic/php-parser" : ">=0.9.2",
+		"nikic/php-parser" : "0.9.5",
 		"codeless/logmore" : ">=0.8.3"
 	},
 	"replace" : {


### PR DESCRIPTION
The nikic/php-parser has changed, and the >= require has required version 2.x of that library which is no longer comparable.